### PR TITLE
Feature/improved cep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip  # See documentation for possible values
+    directory: /  # Location of package manifests
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+---
+name: Python application
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    paths-ignore:
+      - '*.md'
+      - '*.rst'
+      - Makefile
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+          - '3.14'
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - name: 'Install uv and set up Python ${{ matrix.python-version }}'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: '${{ matrix.python-version }}'
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --extra dev
+      - name: Lint with ruff
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          uv run ruff check . --select=E9,F63,F7,F82 --output-format=full
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          uv run ruff check . --exit-zero
+      - name: Test with pytest
+        run: uv run pytest
+      - name: Searchs for know vulnerabities
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A Python 3 (>=3.10) package that validates and formats Brazilian identification numbers/documents: CNPJ, CPF,
 CEP (postal code), Município (municipality codes), PIS/PASEP, CNO, NUPJ (labor lawsuit numbers), and SQL
-("Sequencial de Quadra") for real estate. Zero runtime dependencies.
+("Sequencial de Quadra") for real estate. Zero runtime dependencies for the core package — the one exception is
+the optional `location/extended_cep.py` module (see below), which requires the `extended-cep` extra.
 
 ## Development commands
 
@@ -53,7 +54,7 @@ Code lives under `src/brazilian_ids/functions/<domain>/<id>.py`, grouped by real
 
 - `company/cnpj.py` — CNPJ
 - `person/cpf.py`, `person/pis_pasep.py`
-- `location/cep.py`, `location/municipio.py`, `location/states.py`
+- `location/cep.py`, `location/extended_cep.py`, `location/municipio.py`, `location/states.py`
 - `labor_dispute/nupj.py`
 - `real_state/cno.py`, `real_state/sql.py`
 - `functions/exceptions.py` — shared base exceptions
@@ -101,6 +102,29 @@ Follow this mixin pattern rather than duplicating `id_type()` in each exception 
 Dependency-free. Holds the core `CEP` dataclass (frozen, with `__ge__`/`__le__` for range comparisons),
 `parse`/`format`/`is_valid`, and `is_valid_extended`, which checks a CEP against known per-state numeric ranges
 (`CepRange`, a singleton via the local `Singleton` metaclass) without any network access.
+
+### `location/extended_cep.py`
+
+Validates a CEP against its actual registered state/neighborhood by querying the
+[ViaCEP](https://viacep.com.br/) API, rather than the static ranges in `cep.py`. Needs `httpx` and `pydantic`,
+declared under the `extended-cep` optional dependency group in `pyproject.toml` (also included in the `dev` group
+so `uv sync` pulls them for local development/testing).
+
+- `ViaCepResponse` (`pydantic.BaseModel`) — validates/parses the ViaCEP JSON response shape (`estado`, `bairro`,
+  `erro`, etc).
+- `ViaCepClient` (`abc.ABC`) — abstract interface with one abstract method, `fetch(cep: str) -> ViaCepResponse`;
+  implementations must raise `CepNotFoundError` when the source has no record for the CEP.
+- `ViaCepHttpClient(ViaCepClient)` — concrete implementation using `httpx`, GETs
+  `https://viacep.com.br/ws/<digits>/json/`.
+- `CepDetails` — `@dataclass(frozen=True, slots=True)` holding only the two fields
+  `ExternalSourceCepValidation` actually needs (`state` from `estado`, `location` from `bairro`).
+- `ExternalSourceCepValidation` — takes any `ViaCepClient` plus a `cache_size` (default `DEFAULT_CACHE_SIZE = 300`)
+  and wraps lookups in a per-instance `functools.lru_cache`. Exposes `by_state(cep, state)` and
+  `by_location(cep, state, location)`; both return `False` (rather than raising) for malformed CEPs or a
+  `CepNotFoundError` from the source.
+
+Tests in `tests/test_extended_cep.py` use a `FakeViaCepClient` (a `ViaCepClient` subclass) rather than hitting the
+real ViaCEP API — follow that pattern for any new tests here instead of making real network calls.
 
 ### Tests
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,20 @@ Current supported IDs:
 See the [module documentation](https://brazilian-ids.readthedocs.io/en/latest/)
 for details.
 
+### Extended CEP validation
+
+`brazilian_ids.functions.location.extended_cep` validates a CEP against its actual registered state and
+neighborhood by querying the [ViaCEP](https://viacep.com.br/) API, instead of relying only on the static per-state
+ranges used by the core `cep` module. It requires the `extended-cep` extra:
+
+```
+pip install brazilian-ids[extended-cep]
+```
+
 ## Development
 
-There are no external dependencies to just use the module.
+There are no external dependencies to just use the module, with the exception of the optional
+`extended_cep` module (see above).
 
 Development dependencies are managed with [uv](https://docs.astral.sh/uv/) and declared in the `dev` group of
 `pyproject.toml`. See also the `Makefile` file.

--- a/docs/source/brazilian_ids.functions.location.rst
+++ b/docs/source/brazilian_ids.functions.location.rst
@@ -12,6 +12,14 @@ brazilian\_ids.functions.location.cep module
    :undoc-members:
    :show-inheritance:
 
+brazilian\_ids.functions.location.extended\_cep module
+--------------------------------------------------------
+
+.. automodule:: brazilian_ids.functions.location.extended_cep
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 brazilian\_ids.functions.location.municipio module
 --------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,14 +8,29 @@
 
 import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.abspath(os.path.join("..", "..")), "src"))
+
+def release_from_project():
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # Python < 3.11
+        import tomli as tomllib
+
+    sys.path.insert(0, os.path.join(os.path.abspath(os.path.join("..", "..")), "src"))
+
+    pyproject_file = Path(__file__).resolve().parents[2] / "pyproject.toml"
+
+    with pyproject_file.open("rb") as _fh:
+        pyproject = tomllib.load(_fh)
+
+    return pyproject["project"]["version"]
 
 
 project = "brazilian-ids"
 copyright = "2024, Alceu Rodrigues de Freitas Junior"
 author = "Alceu Rodrigues de Freitas Junior"
-release = "0.0.1"
+release = release_from_project()
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,8 @@
 Welcome to brazilian_ids documentation!
 =======================================
 
+Version |release|
+
 The brazilian_ids is a Python 3 package that provides functions and classes to
 validate several Brazilian IDs.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,9 @@ target-version = "py312"
 select = ["E4", "E7", "E9", "F", "RUF", "UP"]
 
 [tool.bumpversion]
-current_version = "0.3.0"
+# current_version is intentionally not set here: bump-my-version derives it from the latest
+# matching git tag (see tag_name below) so [project].version stays the only version literal
+# written in this file. Bootstrapped with `git tag 0.3.0` to match [project].version above.
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,12 @@ keywords = [
 
 dependencies = []
 
+[project.optional-dependencies]
+extended-cep = [
+    "httpx==0.28.1",
+    "pydantic==2.13.4",
+]
+
 [dependency-groups]
 dev = [
     "bump-my-version==0.25.4",
@@ -50,6 +56,8 @@ dev = [
     "pytest-cov==5.0.0",
     "ruff==0.6.4",
     "Sphinx==8.0.2",
+    "httpx==0.28.1",
+    "pydantic==2.13.4",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ dependencies = []
 
 [project.optional-dependencies]
 extended-cep = ["httpx==0.28.1", "pydantic==2.13.4"]
-
-[dependency-groups]
 dev = [
     "bump-my-version==0.25.4",
     "mypy==1.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "brazilian_ids"
-version = "0.4.0"
+version = "0.3.0"
 authors = [
     { name = "Alceu Rodrigues de Freitas Junior", email = "glasswalk3r@yahoo.com.br" },
 ]
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ target-version = "py312"
 select = ["E4", "E7", "E9", "F", "RUF", "UP"]
 
 [tool.bumpversion]
-current_version = "0.4.0"
+current_version = "0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,7 @@ keywords = [
 dependencies = []
 
 [project.optional-dependencies]
-extended-cep = [
-    "httpx==0.28.1",
-    "pydantic==2.13.4",
-]
+extended-cep = ["httpx==0.28.1", "pydantic==2.13.4"]
 
 [dependency-groups]
 dev = [
@@ -54,10 +51,12 @@ dev = [
     "mypy==1.11.0",
     "pytest==8.3.2",
     "pytest-cov==5.0.0",
-    "ruff==0.6.4",
     "Sphinx==8.0.2",
     "httpx==0.28.1",
     "pydantic==2.13.4",
+    "ruff>=0.16.3",
+    "tox>=4.60.0",
+    "tox-uv-bare>=1.36.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/src/brazilian_ids/functions/location/extended_cep.py
+++ b/src/brazilian_ids/functions/location/extended_cep.py
@@ -1,0 +1,145 @@
+"""Functions and classes to validate CEPs against the ViaCEP external service.
+
+Unlike ``brazilian_ids.functions.location.cep``, which only relies on statically known per-state numeric ranges,
+this module queries `ViaCEP <https://viacep.com.br/>`_ over HTTP to validate a CEP against its actual registered
+state ("estado") and neighborhood ("bairro").
+
+This module has third-party dependencies (``httpx`` and ``pydantic``) that are not part of the package's regular
+runtime dependencies.
+"""
+
+from __future__ import annotations
+
+import weakref
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import lru_cache
+
+import httpx
+from pydantic import BaseModel
+
+from brazilian_ids.functions.location.cep import format as format_cep
+from brazilian_ids.functions.location.cep import is_valid
+from brazilian_ids.functions.util import NONDIGIT_REGEX
+
+DEFAULT_CACHE_SIZE = 300
+
+
+class ViaCepResponse(BaseModel):
+    """Representation of the JSON response returned by the ViaCEP API.
+
+    See also `ViaCEP <https://viacep.com.br/>`_.
+    """
+
+    cep: str = ""
+    logradouro: str = ""
+    complemento: str = ""
+    unidade: str = ""
+    bairro: str = ""
+    localidade: str = ""
+    uf: str = ""
+    estado: str = ""
+    regiao: str = ""
+    ibge: str = ""
+    gia: str = ""
+    ddd: str = ""
+    siafi: str = ""
+    erro: bool = False
+
+
+class CepNotFoundError(ValueError):
+    """Raised when the external source has no record for the given CEP."""
+
+    def __init__(self, cep: str) -> None:
+        super().__init__(f"The CEP '{cep}' was not found")
+        self.cep = cep
+
+
+class ViaCepClient(ABC):
+    """Abstract interface for a client able to fetch CEP details from a ViaCEP-compatible source."""
+
+    @abstractmethod
+    def fetch(self, cep: str) -> ViaCepResponse:
+        """Fetch the details for the given CEP.
+
+        Implementations must raise ``CepNotFoundError`` if the source has no record for ``cep``.
+        """
+        raise NotImplementedError
+
+
+class ViaCepHttpClient(ViaCepClient):
+    """Fetches CEP details from the public ViaCEP REST API over HTTP, using ``httpx``.
+
+    For example, a request for the CEP ``01001000`` is made against
+    ``https://viacep.com.br/ws/01001000/json/``.
+    """
+
+    __base_url = "https://viacep.com.br/ws"
+
+    def __init__(self, client: httpx.Client | None = None) -> None:
+        if client is None:
+            self.__client = httpx.Client()
+            weakref.finalize(self, self.__client.close)
+        else:
+            self.__client = client
+
+    def fetch(self, cep: str) -> ViaCepResponse:
+        digits = NONDIGIT_REGEX.sub("", format_cep(cep))
+        url = f"{self.__base_url}/{digits}/json/"
+
+        response = self.__client.get(url)
+        response.raise_for_status()
+
+        parsed = ViaCepResponse.model_validate(response.json())
+
+        if parsed.erro:
+            raise CepNotFoundError(cep)
+
+        return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class CepDetails:
+    """Minimal, read-only representation of the CEP fields actually used by ``ExternalSourceCepValidation``."""
+
+    state: str
+    location: str
+
+
+class ExternalSourceCepValidation:
+    """Validates CEPs against an external source, caching lookups in memory using a LRU strategy.
+
+    ``state`` and ``location``, as used by this class's methods, correspond respectively to the ``estado`` and
+    ``bairro`` attributes of ``ViaCepResponse``.
+    """
+
+    def __init__(self, source: ViaCepClient, cache_size: int = DEFAULT_CACHE_SIZE) -> None:
+        self.__source = source
+        self.__fetch: Callable[[str], CepDetails] = lru_cache(maxsize=cache_size)(self.__fetch_details)
+
+    def __fetch_details(self, cep: str) -> CepDetails:
+        response = self.__source.fetch(cep)
+        return CepDetails(state=response.estado, location=response.bairro)
+
+    def by_state(self, cep: str, state: str) -> bool:
+        if not is_valid(cep):
+            return False
+
+        try:
+            details = self.__fetch(cep)
+        except CepNotFoundError:
+            return False
+
+        return details.state == state
+
+    def by_location(self, cep: str, state: str, location: str) -> bool:
+        if not is_valid(cep):
+            return False
+
+        try:
+            details = self.__fetch(cep)
+        except CepNotFoundError:
+            return False
+
+        return details.state == state and details.location == location

--- a/tests/test_extended_cep.py
+++ b/tests/test_extended_cep.py
@@ -1,0 +1,104 @@
+import dataclasses
+
+import pytest
+
+from brazilian_ids.functions.location.extended_cep import (
+    CepDetails,
+    CepNotFoundError,
+    ExternalSourceCepValidation,
+    ViaCepClient,
+    ViaCepHttpClient,
+    ViaCepResponse,
+)
+
+
+class FakeViaCepClient(ViaCepClient):
+    """A ``ViaCepClient`` that never hits the network, tracking how many times it was called."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def fetch(self, cep: str) -> ViaCepResponse:
+        self.calls += 1
+
+        if cep == "99999999":
+            raise CepNotFoundError(cep)
+
+        return ViaCepResponse(estado="São Paulo", bairro="Sé")
+
+
+@pytest.fixture
+def fake_client():
+    return FakeViaCepClient()
+
+
+@pytest.fixture
+def validator(fake_client):
+    return ExternalSourceCepValidation(source=fake_client, cache_size=2)
+
+
+def test_via_cep_client_is_abstract():
+    with pytest.raises(TypeError):
+        ViaCepClient()
+
+
+def test_via_cep_http_client_is_a_via_cep_client():
+    assert issubclass(ViaCepHttpClient, ViaCepClient)
+
+
+def test_via_cep_response_parses_a_real_shaped_payload():
+    payload = {
+        "cep": "01001-000",
+        "logradouro": "Praça da Sé",
+        "bairro": "Sé",
+        "localidade": "São Paulo",
+        "uf": "SP",
+        "estado": "São Paulo",
+        "regiao": "Sudeste",
+    }
+
+    result = ViaCepResponse.model_validate(payload)
+
+    assert result.estado == "São Paulo"
+    assert result.bairro == "Sé"
+
+
+def test_via_cep_response_parses_erro_field():
+    result = ViaCepResponse.model_validate({"erro": True})
+    assert result.erro is True
+
+
+def test_cep_details_is_read_only():
+    instance = CepDetails(state="SP", location="Sé")
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        instance.state = "RJ"
+
+
+def test_cep_details_uses_slots():
+    instance = CepDetails(state="SP", location="Sé")
+    assert not hasattr(instance, "__dict__")
+
+
+def test_external_source_cep_validation_by_state(validator):
+    assert validator.by_state("01001000", "São Paulo") is True
+
+
+def test_external_source_cep_validation_by_location(validator):
+    assert validator.by_location("01001000", "São Paulo", "Sé") is True
+
+
+def test_external_source_cep_validation_caches_lookups(validator, fake_client):
+    validator.by_state("01001000", "São Paulo")
+    validator.by_location("01001000", "São Paulo", "Sé")
+
+    assert fake_client.calls == 1
+
+
+def test_external_source_cep_validation_not_found_returns_false(validator):
+    assert validator.by_state("99999999", "São Paulo") is False
+
+
+def test_external_source_cep_validation_malformed_cep_returns_false_without_calling_source(validator, fake_client):
+    assert validator.by_state("123", "São Paulo") is False
+    assert fake_client.calls == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist =
+    3.10
+    3.11
+    3.12
+    3.13
+    3.14
+requires =
+    tox>=4
+    tox-uv-bare>=1.36.0
+
+[testenv]
+description = run unit tests
+runner = uv-venv-lock-runner
+setenv =
+    PYTHONPATH = {toxinidir}
+commands =
+    pytest --basetemp="{envtmpdir}" {posargs}
+

--- a/uv.lock
+++ b/uv.lock
@@ -58,12 +58,6 @@ version = "0.4.0"
 source = { editable = "." }
 
 [package.optional-dependencies]
-extended-cep = [
-    { name = "httpx" },
-    { name = "pydantic" },
-]
-
-[package.dev-dependencies]
 dev = [
     { name = "bump-my-version" },
     { name = "httpx" },
@@ -76,27 +70,27 @@ dev = [
     { name = "tox" },
     { name = "tox-uv-bare" },
 ]
+extended-cep = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
 
 [package.metadata]
 requires-dist = [
+    { name = "bump-my-version", marker = "extra == 'dev'", specifier = "==0.25.4" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = "==0.28.1" },
     { name = "httpx", marker = "extra == 'extended-cep'", specifier = "==0.28.1" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.11.0" },
+    { name = "pydantic", marker = "extra == 'dev'", specifier = "==2.13.4" },
     { name = "pydantic", marker = "extra == 'extended-cep'", specifier = "==2.13.4" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.2" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==5.0.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.3" },
+    { name = "sphinx", marker = "extra == 'dev'", specifier = "==8.0.2" },
+    { name = "tox", marker = "extra == 'dev'", specifier = ">=4.60.0" },
+    { name = "tox-uv-bare", marker = "extra == 'dev'", specifier = ">=1.36.0" },
 ]
-provides-extras = ["extended-cep"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "bump-my-version", specifier = "==0.25.4" },
-    { name = "httpx", specifier = "==0.28.1" },
-    { name = "mypy", specifier = "==1.11.0" },
-    { name = "pydantic", specifier = "==2.13.4" },
-    { name = "pytest", specifier = "==8.3.2" },
-    { name = "pytest-cov", specifier = "==5.0.0" },
-    { name = "ruff", specifier = ">=0.16.3" },
-    { name = "sphinx", specifier = "==8.0.2" },
-    { name = "tox", specifier = ">=4.60.0" },
-    { name = "tox-uv-bare", specifier = ">=1.36.0" },
-]
+provides-extras = ["extended-cep", "dev"]
 
 [[package]]
 name = "bump-my-version"

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,7 @@ wheels = [
 
 [[package]]
 name = "brazilian-ids"
-version = "0.4.0"
+version = "0.3.0"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "sphinx" },
+    { name = "tox" },
+    { name = "tox-uv-bare" },
 ]
 
 [package.metadata]
@@ -90,8 +92,10 @@ dev = [
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pytest", specifier = "==8.3.2" },
     { name = "pytest-cov", specifier = "==5.0.0" },
-    { name = "ruff", specifier = "==0.6.4" },
+    { name = "ruff", specifier = ">=0.16.3" },
     { name = "sphinx", specifier = "==8.0.2" },
+    { name = "tox", specifier = ">=4.60.0" },
+    { name = "tox-uv-bare", specifier = ">=1.36.0" },
 ]
 
 [[package]]
@@ -111,6 +115,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/65/3a/1f7de0bff28a05f44bd90fcda63ef1f067ca5d30b176d2841ee65f5a5790/bump_my_version-0.25.4.tar.gz", hash = "sha256:06a96dd6bb36b39b1f8cf37368c52794f89ba392780ac3c697fcf751a134f9a5", size = 105271, upload-time = "2024-08-14T14:13:28.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/45/07/b2840786a6d17ea2a6151ed779cd3ce8daf1d20b37412209ba01feaa9614/bump_my_version-0.25.4-py3-none-any.whl", hash = "sha256:cedcb408101cce6413d9b390c7af6c5424dbfde95549d3eef35b19f81940c5bb", size = 49945, upload-time = "2024-08-14T14:13:27.341Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/d2/47e8bc06fe2a06d3f5bdf20f1126ab66c4e99dc48d940e7ba873f7ac7131/cachetools-7.1.7.tar.gz", hash = "sha256:a3e2a00b14d8f8a6b70c1dae7b4685e7ad3bc965c5b42124a2d6ce895da6cf50", size = 40680, upload-time = "2026-08-01T21:20:40.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d8/767faeda872075724b95dd675466a645f1b92aadcdcf2d1429dcfd76c176/cachetools-7.1.7-py3-none-any.whl", hash = "sha256:ef98ef375ad188819ef2f9b3645e3987f4b8c5b7550e436ad998c2de78296df0", size = 16830, upload-time = "2026-08-01T21:20:38.977Z" },
 ]
 
 [[package]]
@@ -364,6 +377,15 @@ toml = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -382,6 +404,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/64/a02e6765de08964ed371eca577870593245afc9dfac16d037de7c10d18e6/filelock-3.32.3.tar.gz", hash = "sha256:0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f", size = 218135, upload-time = "2026-08-13T16:00:05.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/8e/50f46a9c0ce8d2861a394c1347caae037ea0431d2f67d7feb151cbc4649a/filelock-3.32.3-py3-none-any.whl", hash = "sha256:7f0ca4bcc0e181c60dbbd8aa9ab5b120ebb99e4e064e83636340056f833a1f09", size = 98901, upload-time = "2026-08-13T16:00:03.974Z" },
 ]
 
 [[package]]
@@ -614,6 +645,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.11.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/d7/e7bfbc86e9f99ff7807e24de7703f032e9c9ba80bb355cf26e0e9bc5a75e/platformdirs-4.11.3.tar.gz", hash = "sha256:66a73d38a849810252df809a3d8bcbda8e26f6c189920e7535ad608a48dbb5ab", size = 33050, upload-time = "2026-08-13T22:43:27.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/a9/c34aebedd3a4c9afe5101b1b8713710b3fec18087c8a36c35d2f909861bd/platformdirs-4.11.3-py3-none-any.whl", hash = "sha256:5ed065d443751de711da036041a7a214122efc4a4de393b3f4137ba5576540e7", size = 23491, upload-time = "2026-08-13T22:43:26.121Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -789,6 +829,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/bd/2f985c12bf33fdd8637e3a8f9418d6806f177601dee7c4924d0b2bb28650/pyproject_api-1.11.0.tar.gz", hash = "sha256:b8807d85a293e6c9f133e6575946fed45f1d42b22d58c780b33aa2421a799549", size = 23787, upload-time = "2026-07-21T13:09:33.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/6a/2822ee12bafe87af8f6cc620f7d1f126e77f82ce56ba888b94a9af5a979c/pyproject_api-1.11.0-py3-none-any.whl", hash = "sha256:860060c8832dce983b5eec6f41c4c43eb3ec06ff7332387a63acdf5ca27b68d8", size = 13275, upload-time = "2026-07-21T13:09:32.559Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +869,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/67/00efc8d11b630c56f15f4ad9c7f9223f1e5ec275aaae3fa9118c6a223ad2/pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857", size = 63042, upload-time = "2024-03-24T20:16:34.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/3a/af5b4fa5961d9a1e6237b530eb87dd04aea6eb83da09d2a4073d81b54ccf/pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652", size = 21990, upload-time = "2024-03-24T20:16:32.444Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/b7/ac44da2cf0e53ada0e419033c2d058219c95dc1403126f163304c9e814b1/python_discovery-1.5.2.tar.gz", hash = "sha256:45fd4f20a4e3f9b7bf2e0817870bc8e3b320a19658da177af800768c82dbf354", size = 82350, upload-time = "2026-08-12T14:05:26.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/45/689603d04b3bb8d7faa00f25c24acef993aab7813b3dbbfc472a459ab0b5/python_discovery-1.5.2-py3-none-any.whl", hash = "sha256:3e338c2d0f15dfaeea57493f4c2c6caebe0e998ea815c30ae8bf8ee21f1112d3", size = 38350, upload-time = "2026-08-12T14:05:25.113Z" },
 ]
 
 [[package]]
@@ -884,27 +949,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.6.4"
+version = "0.16.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/55/9f485266e6326cab707369601b13e3e72eb90ba3eee2d6779549a00a0d58/ruff-0.6.4.tar.gz", hash = "sha256:ac3b5bfbee99973f80aa1b7cbd1c9cbce200883bdd067300c22a6cc1c7fba212", size = 2469375, upload-time = "2024-09-05T15:51:36.418Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/b3/3213589383f8f1b3938781bd1278713f6d18621a14992b3e81fefb8a5ef9/ruff-0.16.3.tar.gz", hash = "sha256:e76d33a347661a84b5be6d043d0347fdc745dfdcf825a8f4fed64b5e26eebdf2", size = 4891904, upload-time = "2026-08-13T15:17:13.381Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/78/307591f81d09c8721b5e64539f287c82c81a46f46d16278eb27941ac17f9/ruff-0.6.4-py3-none-linux_armv6l.whl", hash = "sha256:c4b153fc152af51855458e79e835fb6b933032921756cec9af7d0ba2aa01a258", size = 9692673, upload-time = "2024-09-05T15:50:50.469Z" },
-    { url = "https://files.pythonhosted.org/packages/69/63/ef398fcacdbd3995618ed30b5a6c809a1ebbf112ba604b3f5b8c3be464cf/ruff-0.6.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bedff9e4f004dad5f7f76a9d39c4ca98af526c9b1695068198b3bda8c085ef60", size = 9481182, upload-time = "2024-09-05T15:50:54.027Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/fd/8784e3bbd79bc17de0a62de05fe5165f494ff7d77cb06630d6428c2f10d2/ruff-0.6.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d02a4127a86de23002e694d7ff19f905c51e338c72d8e09b56bfb60e1681724f", size = 9174356, upload-time = "2024-09-05T15:50:56.694Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/bc/c69db2d68ac7bfbb222c81dc43a86e0402d0063e20b13e609f7d17d81d3f/ruff-0.6.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7862f42fc1a4aca1ea3ffe8a11f67819d183a5693b228f0bb3a531f5e40336fc", size = 10129365, upload-time = "2024-09-05T15:50:59.674Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/10/8ed14ff60a4e5eb08cac0a04a9b4e8590c72d1ce4d29ef22cef97d19536d/ruff-0.6.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eebe4ff1967c838a1a9618a5a59a3b0a00406f8d7eefee97c70411fefc353617", size = 9483351, upload-time = "2024-09-05T15:51:02.296Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/69/13316b8d64ffd6a43627cf0753339a7f95df413450c301a60904581bee6e/ruff-0.6.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:932063a03bac394866683e15710c25b8690ccdca1cf192b9a98260332ca93408", size = 10301099, upload-time = "2024-09-05T15:51:04.68Z" },
-    { url = "https://files.pythonhosted.org/packages/42/00/9623494087272643e8f02187c266638306c6829189a5bf1446968bbe438b/ruff-0.6.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:50e30b437cebef547bd5c3edf9ce81343e5dd7c737cb36ccb4fe83573f3d392e", size = 11033216, upload-time = "2024-09-05T15:51:07.111Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/31/e0c9d881db42ea1267e075c29aafe0db5a8a3024b131f952747f6234f858/ruff-0.6.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c44536df7b93a587de690e124b89bd47306fddd59398a0fb12afd6133c7b3818", size = 10618140, upload-time = "2024-09-05T15:51:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/35/f1d8b746aedd4c8fde4f83397e940cc4c8fc619860ebbe3073340381a34d/ruff-0.6.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ea086601b22dc5e7693a78f3fcfc460cceabfdf3bdc36dc898792aba48fbad6", size = 11606672, upload-time = "2024-09-05T15:51:12.554Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/70/899b03cbb3eb48ed0507d4b32b6f7aee562bc618ef9ffda855ec98c0461a/ruff-0.6.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b52387d3289ccd227b62102c24714ed75fbba0b16ecc69a923a37e3b5e0aaaa", size = 10288013, upload-time = "2024-09-05T15:51:15.487Z" },
-    { url = "https://files.pythonhosted.org/packages/17/c6/906bf895640521ca5115ccdd857b2bac42bd61facde6620fdc2efc0a4806/ruff-0.6.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0308610470fcc82969082fc83c76c0d362f562e2f0cdab0586516f03a4e06ec6", size = 10109473, upload-time = "2024-09-05T15:51:17.623Z" },
-    { url = "https://files.pythonhosted.org/packages/28/da/1284eb04172f8a5d42eb52fce9d643dd747ac59a4ed6c5d42729f72e934d/ruff-0.6.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:803b96dea21795a6c9d5bfa9e96127cc9c31a1987802ca68f35e5c95aed3fc0d", size = 9568817, upload-time = "2024-09-05T15:51:20.771Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/e2/f8250b54edbb2e9222e22806e1bcc35a192ac18d1793ea556fa4977a843a/ruff-0.6.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:66dbfea86b663baab8fcae56c59f190caba9398df1488164e2df53e216248baa", size = 9910840, upload-time = "2024-09-05T15:51:23.565Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/7c/dcf2c10562346ecdf6f0e5f6669b2ddc9a74a72956c3f419abd6820c2aff/ruff-0.6.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34d5efad480193c046c86608dbba2bccdc1c5fd11950fb271f8086e0c763a5d1", size = 10354263, upload-time = "2024-09-05T15:51:26.604Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/94/c39d7ac5729e94788110503d928c98c203488664b0fb92c2b801cb832bec/ruff-0.6.4-py3-none-win32.whl", hash = "sha256:f0f8968feea5ce3777c0d8365653d5e91c40c31a81d95824ba61d871a11b8523", size = 7958602, upload-time = "2024-09-05T15:51:29.563Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d2/2dee8c547bee3d4cfdd897f7b8e38510383acaff2c8130ea783b67631d72/ruff-0.6.4-py3-none-win_amd64.whl", hash = "sha256:549daccee5227282289390b0222d0fbee0275d1db6d514550d65420053021a58", size = 8795059, upload-time = "2024-09-05T15:51:31.994Z" },
-    { url = "https://files.pythonhosted.org/packages/07/1a/23280818aa4fa89bd0552aab10857154e1d3b90f27b5b745f09ec1ac6ad8/ruff-0.6.4-py3-none-win_arm64.whl", hash = "sha256:ac4b75e898ed189b3708c9ab3fc70b79a433219e1e87193b4f2b77251d058d14", size = 8239636, upload-time = "2024-09-05T15:51:34.17Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/493770daebd68c0a67f1549fdf519f53be51fc435186c0585bcc272fd76c/ruff-0.16.3-py3-none-linux_armv6l.whl", hash = "sha256:0c5710e247a58a4521e66e124ba9a74655b414f61ba3a2e9e3811e11098f48f7", size = 10902799, upload-time = "2026-08-13T15:16:27.382Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/2becf3942fddc29a29b8df47691d456fb1085391a694f74d84513251418c/ruff-0.16.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fe155130631a2471fd2e14a7a664a4dfbd7194b8229c3d7b2a40b21178639081", size = 11135539, upload-time = "2026-08-13T15:16:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/1e/4b8b72f0d006dbf19326aa99f9ca0ee2ff374187c4d301cf529a51aa06fe/ruff-0.16.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e2ed719e14aa64d895c2ee922594a90a43c861a93f0575a95ff8c47cdbd13eb9", size = 10475095, upload-time = "2026-08-13T15:16:33.259Z" },
+    { url = "https://files.pythonhosted.org/packages/92/32/2201fa49ba1f6c101ee321e83f051ac7a4b8d07b0ef6b4d3f2772b302275/ruff-0.16.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e0b1da805eb043654645d74d5de1e5ce2edc686e40790d2b86f56d71cc06a84", size = 10668771, upload-time = "2026-08-13T15:16:35.65Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/66/4afc5c8363bd04d45effce1b7c8713ca037d7a6740b7451a2403a6e3a972/ruff-0.16.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a37bdea0bbe21780f590bf437d6412c8c4e1b6cd010f91a65c2c40c5e5f5f870", size = 10699568, upload-time = "2026-08-13T15:16:38.195Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/c67d246bf36bf1698551c56de39e95cd07f70e64433e0098e6267d77061b/ruff-0.16.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09571e6d1288ed9be475207a3ac04ada404f1cd898104be0f6ab8d7df438575b", size = 11499365, upload-time = "2026-08-13T15:16:40.623Z" },
+    { url = "https://files.pythonhosted.org/packages/67/0b/00ecbceb99a263af7b12f6f05ac3c92bc47b905e91adc3f207a836e3bc01/ruff-0.16.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2c18c5a101eb540010638cc1ff3c84944d3adb3df62b8d98ca8f22ba484d3413", size = 12311728, upload-time = "2026-08-13T15:16:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/b7b3bb54f4d3f7db504e476ad4ab8de530dceebe2c061384b2757ee419e8/ruff-0.16.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8457c44f15033c85ddbb77b15d451df9e24e4bd03b628396dd3610cedc3b8f82", size = 11699896, upload-time = "2026-08-13T15:16:46.209Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/4c468429ac195addc5ee1b717b6ab1b66632786737ca3b2ed3443fb0c26a/ruff-0.16.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:294b95c4ae0cda9388525c2047778aa758d6b8d4bb876fd4e9eaa3ebc92343eb", size = 11058736, upload-time = "2026-08-13T15:16:48.823Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/7a113cdaddf24b64d7f75b1242a99d04c82fcef4f6921fdbb832beaffb5f/ruff-0.16.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:3d0c7c40c87c2a820509c31ba007968da6e1306468c067b2d82fbfdbcd0e8474", size = 11586911, upload-time = "2026-08-13T15:16:51.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c1/2e66f24c0f3ead25a5e660111778685e505e5da353c82802bf49f0cbe7b9/ruff-0.16.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:9f738c0fdfa8eed0b2ce7fb27ee7258208a92a68d7949e62aa15164bc7b389da", size = 10954265, upload-time = "2026-08-13T15:16:54.763Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/ba/4cee23bf52cba9a058d3726de623624daf50ef9638868edd86f4126157f6/ruff-0.16.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fb785f0be25abe69d320415cd4f833b59e17ba7613d9ba6a958023b6bceb0a50", size = 10709886, upload-time = "2026-08-13T15:16:57.339Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/7da7194fa5d9dc0a285f7e6fa5a4722e7c63faac0b45b614ded9314363a1/ruff-0.16.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c5536e3acfbf9563085aa2be7b13c629c3077e902afc5b941ac44024dbb9f506", size = 11210392, upload-time = "2026-08-13T15:17:00.171Z" },
+    { url = "https://files.pythonhosted.org/packages/35/85/7795f6e817af050e7517bf3e7aa9b061cce70ef33d280aad902c956c1ecf/ruff-0.16.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a2d85c02f9b8e165d85e6779184d38c4132de12603dab59c51c28e22584f9e4d", size = 11626910, upload-time = "2026-08-13T15:17:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9b/475b927cf27a5cbbda3c7bafb69ed6ff77e1d7923d5d85f17c2749d7ae32/ruff-0.16.3-py3-none-win32.whl", hash = "sha256:388cdf2166642bd9b13d52b5932d3170f34f8abed7e8d9a855f1d84b83645a0a", size = 10931415, upload-time = "2026-08-13T15:17:05.726Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/99/e2a2bfc4fbf0a1e8a916bc9ebe6fe6c58cc34c28e0ffc6ce281d572d1c2e/ruff-0.16.3-py3-none-win_amd64.whl", hash = "sha256:e80a7d69ca2a6d1c4d352ec91458cdca6e56c83cdbcabd93e4abe1e53591d948", size = 11445993, upload-time = "2026-08-13T15:17:08.353Z" },
+    { url = "https://files.pythonhosted.org/packages/69/3e/4132e539aed78c148854d4997a2685b0ed4dc4e87110b59ce528564e184e/ruff-0.16.3-py3-none-win_arm64.whl", hash = "sha256:b8ca152da82c1acc1fa8d5874b15951935f0eef46f10e6954c83859011b6178a", size = 11399302, upload-time = "2026-08-13T15:17:10.908Z" },
 ]
 
 [[package]]
@@ -1053,12 +1118,58 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
+]
+
+[[package]]
+name = "tox"
+version = "4.60.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "colorama" },
+    { name = "filelock" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pluggy" },
+    { name = "pyproject-api" },
+    { name = "python-discovery" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/1f/3acba68301b0081cec87b1769ba4c3a4a0a30f20879a05420673c7e4671d/tox-4.60.0.tar.gz", hash = "sha256:6f93bb580d35e00fc69cfec1116eecbe21155f747753ca5019374f7c69b2eac9", size = 301598, upload-time = "2026-08-13T23:14:26.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/e6/3a1042add765c0e1e67f76a3b0f2036bfe6b0229ace83c6ff9638a5e391b/tox-4.60.0-py3-none-any.whl", hash = "sha256:175abbc4cdef615d66874c0843be4f44c353c14aab6d89939bb22246f84122bd", size = 226332, upload-time = "2026-08-13T23:14:25.324Z" },
+]
+
+[[package]]
+name = "tox-uv-bare"
+version = "1.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tox" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/df/9f90a59de8c87cece6e691eee53dc1cb0a824d73aea8f380ae2f6ecb71de/tox_uv_bare-1.36.0.tar.gz", hash = "sha256:d9b0a2fd0f74fa65d9597108f8a0ef7abb08651c9196a998a6073b781b45cfd0", size = 32548, upload-time = "2026-07-21T13:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/0a/6dc462e4fb543305283a6157c80f43e3d12ca4702da6ae6521d541c6b55c/tox_uv_bare-1.36.0-py3-none-any.whl", hash = "sha256:ba397dd0396df95a75744d4e42a50ee27207c0ffcf277b62ffba9c3de455a939", size = 22489, upload-time = "2026-07-21T13:09:55.389Z" },
 ]
 
 [[package]]
@@ -1089,6 +1200,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.7.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,20 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -43,10 +57,18 @@ name = "brazilian-ids"
 version = "0.4.0"
 source = { editable = "." }
 
+[package.optional-dependencies]
+extended-cep = [
+    { name = "httpx" },
+    { name = "pydantic" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "bump-my-version" },
+    { name = "httpx" },
     { name = "mypy" },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -54,11 +76,18 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "httpx", marker = "extra == 'extended-cep'", specifier = "==0.28.1" },
+    { name = "pydantic", marker = "extra == 'extended-cep'", specifier = "==2.13.4" },
+]
+provides-extras = ["extended-cep"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bump-my-version", specifier = "==0.25.4" },
+    { name = "httpx", specifier = "==0.28.1" },
     { name = "mypy", specifier = "==1.11.0" },
+    { name = "pydantic", specifier = "==2.13.4" },
     { name = "pytest", specifier = "==8.3.2" },
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "ruff", specifier = "==0.6.4" },
@@ -353,6 +382,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Summary

Migrates the project's tooling stack from pip/flake8/setuptools to uv, adds CI, and ships a new opt-in extended CEP validation feature backed by the ViaCEP API.

## Tooling migration

- Dependency management → uv: requirements-dev.txt and the standalone .bumpversion.toml are removed; dev tooling now lives in [project.optional-dependencies].dev in pyproject.toml, with bump-my-version config folded into [tool.bumpversion] there too. uv.lock is now committed.
- Makefile targets rewritten to go through uv run/uv sync/uv build/uv publish (replacing bare python/pip/twine/setup.py install); lint now runs ruff check + mypy instead of flake8.
- Linter → ruff: replaces flake8. [tool.ruff.lint].select adds RUF and UP on top of the defaults (E4,E7,E9,F).
- Type checking: mypy added to the lint step.
- tox.ini added (via tox-uv-bare) to run the test suite across Python 3.10–3.14.
- requires-python raised from >=3.8 to >=3.10; classifiers drop 3.8/3.9, add 3.13/3.14.

## CI

- New .github/workflows/main.yml: matrix build across Python 3.10–3.14, using astral-sh/setup-uv, running ruff, pytest, and pypa/gh-action-pip-audit for vulnerability scanning.
- New .github/dependabot.yml for weekly pip and github-actions update checks.

## New feature: extended CEP validation

- src/brazilian_ids/functions/location/extended_cep.py (new, ~145 lines): validates a CEP against its real registered state/neighborhood via the ViaCEP API, as an alternative to the static ranges in cep.py.
  - ViaCepClient (abstract) / ViaCepHttpClient (httpx-based concrete implementation)
  - ViaCepResponse — Pydantic model for the ViaCEP JSON shape
  - CepDetails — frozen, slotted dataclass holding just state/location
  - ExternalSourceCepValidation — wraps lookups in a per-instance LRU cache (default 300 entries), exposing by_state()/by_location()
- Gated behind the new extended-cep optional dependency group (httpx, pydantic) so the core package stays dependency-free.
- New tests/test_extended_cep.py (11 tests) using a fake ViaCepClient — no real network calls.

## Bug fixes / cleanups (ruff/mypy-driven)

- Fixed invalid ClassVar annotations in nupj.py that were breaking test collection (ClassVar[dict[int], tuple[str,str]] → properly nested generics).
- Fixed several bad printf→f-string conversions left over from an earlier automated pass: cpf.py, pis_pasep.py, cnpj.py, cno.py (pad(), e.g. f"{int(cpf):0.011i}" → f"{int(cpf):011d}"), and nupj.py (f"{i:02d}" % i → f"{i:02d}", 3 occurrences).
- Fixed the Singleton metaclass in location/cep.py (typed ClassVar for _instances, zero-arg super()).
- Modernized .format() calls to f-strings in exceptions.py, municipio.py, sql.py; set([...]) → set literal in states.py; dict.keys() membership check in municipio.py; open(csv, "r") → open(csv) in tests/test_cpf.py; None | str → str | None in exceptions.py.

## Documentation

- New CLAUDE.md documenting module layout, per-ID conventions, exception hierarchy, and dev workflow for future Claude Code sessions.
- README.md: documents the extended-cep extra and uv-based dev workflow.
- Sphinx docs: conf.py now derives release from pyproject.toml (via tomllib) instead of a hardcoded, stale "0.0.1"; index.rst surfaces Version |release| in the page body (previously only appeared in the <title> tag); new .rst section documenting extended_cep.
- .gitignore adds .ruff_cache and .claude.